### PR TITLE
Namespace Proxy Request IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tangier-ai/mcp-runner",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tangier-ai/mcp-runner",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangier-ai/mcp-runner",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Dockerized API for running and connecting to MCP servers securely and remotely built in TypeScript",
   "main": "src/app.ts",
   "repository": {

--- a/src/controllers/sse-mcp-server.controller.ts
+++ b/src/controllers/sse-mcp-server.controller.ts
@@ -12,7 +12,8 @@ export class SSEMcpServerController {
   @ApiOperation({
     operationId: "mcpServerSSE",
     summary: "Establish MCP SSE connection",
-    description: "Server-Sent Events transport endpoint for establishing real-time, bidirectional communication with the MCP server. Enables streaming of server-to-client events and supports connection resumption via Last-Event-ID header.",
+    description:
+      "Server-Sent Events transport endpoint for establishing real-time, bidirectional communication with the MCP server. Enables streaming of server-to-client events and supports connection resumption via Last-Event-ID header.",
   })
   @ApiParam({
     name: "deployment_id",
@@ -41,7 +42,8 @@ export class SSEMcpServerController {
   @ApiOperation({
     operationId: "mcpServerMessages",
     summary: "Send MCP JSON-RPC messages via SSE",
-    description: "SSE transport endpoint for sending client-to-server JSON-RPC messages while maintaining the SSE connection for server responses and real-time event streaming.",
+    description:
+      "SSE transport endpoint for sending client-to-server JSON-RPC messages while maintaining the SSE connection for server responses and real-time event streaming.",
   })
   @ApiParam({
     name: "deployment_id",

--- a/src/mcp-transports/streamable-http-server-transport-server-proxy.ts
+++ b/src/mcp-transports/streamable-http-server-transport-server-proxy.ts
@@ -60,7 +60,9 @@ export class StreamableHttpServerTransportServerProxy extends StreamableHTTPServ
       const prefix = this.sessionId + "::";
 
       if ("id" in message && message.id.toString().startsWith(prefix)) {
-        let originalId = message.id.toString().slice(prefix.length);
+        let originalId: number | string = message.id
+          .toString()
+          .slice(prefix.length);
 
         if (this.usesNumericalIds) {
           originalId = Number(originalId);

--- a/src/mcp-transports/streamable-http-server-transport-server-proxy.ts
+++ b/src/mcp-transports/streamable-http-server-transport-server-proxy.ts
@@ -107,6 +107,7 @@ export class StreamableHttpServerTransportServerProxy extends StreamableHTTPServ
   async start(): Promise<void> {
     // start the underlying MCP Client Transport when the Streamable HTTP Server Transport starts
     await this.client.start();
+    await super.start();
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
This is because when we're forwarding messages to the underlying MCP server (STDIO in most common situation) it is possible that the external MCP client sent us a message with some predictable, duplicate ID like `ID: 0`

This messes up the streamable http transport which uses the Request IDs to map to the response streams. We bypass this issue by creating namespaced IDs (prefixed with the session ID) for each message so that there's never any duplicate IDs in responses from the underlying MCP server.